### PR TITLE
fix: book card metadata box not full width

### DIFF
--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -21,8 +21,6 @@ const BookCard = ({
 }: BookCardProps): ReactElement => {
   const { isMobile } = useMobile();
 
-  console.log(book.pageNumber);
-
   return (
     <ItemCardLayout
       title={book.title}

--- a/frontend/src/components/layout/ItemCardLayout.tsx
+++ b/frontend/src/components/layout/ItemCardLayout.tsx
@@ -103,7 +103,7 @@ const ItemCardLayout = ({
             </Box>
           )}
         </Box>
-        <CardContent sx={{ px: "12px", pt: "10px", pb: "8px" }}>
+        <CardContent sx={{ width: "100%", px: "12px", pt: "10px", pb: "8px" }}>
           <Typography
             variant="h6"
             sx={{


### PR DESCRIPTION
## Description

The book card metadata box is not at full width, resulting in no space being between the location and the page number.

## Related Issue(s)

_None_

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Motivation and Context

_None_

## Checklist

- [ ] ~~Tests added/updated~~
- [ ] ~~Docs updated (if needed)~~

## Additional Notes

_None_
