### PR TITLE
fix: dont display a read/download button, if no book file is uploaded

### DIFF
--- a/frontend/src/features/LocationDetails.tsx
+++ b/frontend/src/features/LocationDetails.tsx
@@ -57,7 +57,7 @@ const LocationDetails = ({
         </Button>
       </Stack>
     );
-  } else if (LocalTypes.includes(location.type ?? -1)) {
+  } else if (LocalTypes.includes(location.type ?? -1) && location.fileInfo) {
     const fileUrl = FileUrl({
       id: bookId,
       location: {

--- a/frontend/src/utils/FileUtils.tsx
+++ b/frontend/src/utils/FileUtils.tsx
@@ -10,7 +10,7 @@ export const UrlToFile = async (url: string): Promise<File> => {
 };
 
 export const CoverUrl = (book: BookDTO | undefined): string | undefined => {
-  if (book === undefined || book?.cover === undefined) {
+  if (book === undefined || book?.cover === undefined || book?.cover === null) {
     return undefined;
   }
 
@@ -21,7 +21,8 @@ export const BookFileUrl = (book: BookDTO | undefined): string | undefined => {
   if (
     book === undefined ||
     book?.location?.type !== 1 ||
-    book?.location?.fileInfo === undefined
+    book?.location?.fileInfo === undefined ||
+    book?.location?.fileInfo === null
   ) {
     return undefined;
   }


### PR DESCRIPTION
## Description

Down display a read/download button if no book file is uploaded.

## Motivation and Context

The read/download button just link to nothing, possibly confusing users.

## Type of Change

- [ ] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)

## Related Issue(s)

_None_

## Additional Notes

_None_
