### PR TITLE
fix: dont show volume number in metadata cover image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It supports both digital books (EPUB, PDF, etc.) and physical collections, with 
   - Bulk import from CSV ([see Guide](docs/quickstart.md#22-import-in-bulk-from-csv))
 - Browse and search books, series, author and tags _(planned)_
 - Full user metadata editing (notes, read status, favorite) _(planned)_
-  - Import metadata from OpenLibrary ([see Guide](docs/quickstart.md#23-import-metadata))
+  - Import metadata from Amazon, Google and OpenLibrary ([see Guide](docs/quickstart.md#23-import-metadata))
 - Shelves and filtering (tags, categories, series, location) _(planned)_
 - OPDS support for eReaders _(planned)_
 

--- a/frontend/src/components/MetadataCard.tsx
+++ b/frontend/src/components/MetadataCard.tsx
@@ -45,11 +45,6 @@ const MetadataCard = ({
     onClick={onClick ? (): void => onClick(metadata) : undefined}
     image={metadata.coverUrl}
     fallbackImage={bookCover}
-    badge={
-      metadata.volume !== null && metadata.volume !== 0
-        ? metadata.volume?.toString()
-        : ""
-    }
     squareBadge={true}
     metadata={[
       <AuthorMetadata key="author" metadata={metadata} />,


### PR DESCRIPTION
## Description

Dont display the volume number in the metadata cover image.

## Motivation and Context

1. The volume number is shown next to the series in the fields
2. It looks ugly

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] Tests added/updated
- [x] Docs updated (if needed)

## Related Issue(s)



## Additional Notes


