### PR TITLE
fix: amazon metadata source did not return any books

### DIFF
--- a/backend/src/KapitelShelf.Api/Logic/MetadataScraper/AmazonScraper.cs
+++ b/backend/src/KapitelShelf.Api/Logic/MetadataScraper/AmazonScraper.cs
@@ -29,7 +29,7 @@ public partial class AmazonScraper(HttpClient httpClient) : MetadataScraperBase
     /// Initializes a new instance of the <see cref="AmazonScraper"/> class.
     /// </summary>
     public AmazonScraper()
-        : this(new HttpClient())
+        : this(CreateHttpClient())
     {
     }
 

--- a/backend/src/KapitelShelf.Api/Logic/MetadataScraper/GoogleScraper.cs
+++ b/backend/src/KapitelShelf.Api/Logic/MetadataScraper/GoogleScraper.cs
@@ -19,7 +19,7 @@ public class GoogleScraper(HttpClient httpClient) : MetadataScraperBase
     /// Initializes a new instance of the <see cref="GoogleScraper"/> class.
     /// </summary>
     public GoogleScraper()
-        : this(new HttpClient())
+        : this(CreateHttpClient())
     {
     }
 

--- a/backend/src/KapitelShelf.Api/Logic/MetadataScraper/MetadataScraperBase.cs
+++ b/backend/src/KapitelShelf.Api/Logic/MetadataScraper/MetadataScraperBase.cs
@@ -49,4 +49,19 @@ public abstract partial class MetadataScraperBase : IMetadataScraper
 
     /// <inheritdoc/>
     public abstract Task<List<MetadataDTO>> Scrape(string title);
+
+    /// <summary>
+    /// Create a new http client.
+    /// </summary>
+    /// <returns>The http client.</returns>
+    protected static HttpClient CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = System.Net.DecompressionMethods.GZip |
+                                         System.Net.DecompressionMethods.Deflate |
+                                         System.Net.DecompressionMethods.Brotli,
+        };
+        return new HttpClient(handler);
+    }
 }

--- a/backend/src/KapitelShelf.Api/Logic/MetadataScraper/OpenLibraryScraper.cs
+++ b/backend/src/KapitelShelf.Api/Logic/MetadataScraper/OpenLibraryScraper.cs
@@ -19,7 +19,7 @@ public class OpenLibraryScraper(HttpClient httpClient) : MetadataScraperBase
     /// Initializes a new instance of the <see cref="OpenLibraryScraper"/> class.
     /// </summary>
     public OpenLibraryScraper()
-        : this(new HttpClient())
+        : this(CreateHttpClient())
     {
     }
 


### PR DESCRIPTION
## Description

The amazon metadata source did not return any books, regardless of title.

## Motivation and Context

Bug

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)

## Related Issue(s)



## Additional Notes


