### PR TITLE
fix: anchor ref attribute spelling error

### DIFF
--- a/frontend/src/features/location/LocationDetails.tsx
+++ b/frontend/src/features/location/LocationDetails.tsx
@@ -81,7 +81,7 @@ const LocationDetails = ({
           component={Link}
           href={fileUrl}
           target="_blank"
-          rel="noreferer"
+          rel="noreferrer"
           disabled={fileUrl === undefined}
         >
           Download
@@ -97,7 +97,7 @@ const LocationDetails = ({
           startIcon={<AutoStoriesIcon />}
           href={location.url ?? undefined}
           target="_blank"
-          rel="noreferer"
+          rel="noreferrer"
         >
           Read on {LocationTypeToString[location.type ?? -1]}
         </Button>


### PR DESCRIPTION
## Summary
- fix `rel` attribute typo on download and external link buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ae0d5337483289bed20ac9ad491c3