### PR TITLE
fix: set domain for cloudstorage configuration

### DIFF
--- a/backend/src/KapitelShelf.Api/Dockerfile
+++ b/backend/src/KapitelShelf.Api/Dockerfile
@@ -32,7 +32,7 @@ RUN dotnet restore "./KapitelShelf.Api.csproj" && \
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS production
 
 # versions
-ARG RCLONE_VERSION=v1.65.2
+ARG RCLONE_VERSION=v1.71.0
 
 WORKDIR /app
 

--- a/development/steps/setup_rclone.ps1
+++ b/development/steps/setup_rclone.ps1
@@ -1,9 +1,11 @@
 # setup.ps1
 # Downloads the latest rclone.exe for Windows x64 and puts it in ./3rd-party
 
+$RCLONE_VERSION = "v1.71.0"
+
 $ErrorActionPreference = "Stop"
 
-$downloadUrl = "https://downloads.rclone.org/rclone-current-windows-amd64.zip"
+$downloadUrl = "https://github.com/rclone/rclone/releases/download/$RCLONE_VERSION/rclone-$RCLONE_VERSION-windows-amd64.zip"
 $targetDir = Join-Path $PSScriptRoot ".." "3rd-party"
 
 if (-not (Test-Path $targetDir)) {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,6 +60,7 @@ docker run -d \
     -e KapitelShelf__Database__Host=host.docker.internal:5432 \
     -e KapitelShelf__Database__Username=kapitelshelf \
     -e KapitelShelf__Database__Password=kapitelshelf \
+    -e KapitelShelf__Domain=https://localhost:5261 \
     -v ./data:/var/lib/kapitelshelf/data
     --restart unless-stopped \
     thomasmiller01/kapitelshelf-api
@@ -73,3 +74,4 @@ docker run -d \
 | `KapitelShelf__Database__Host`     | `host.docker.internal:5432`  | `KapitelShelf.Database.Host`     |
 | `KapitelShelf__Database__Username` | `kapitelshelf`               | `KapitelShelf.Database.Username` |
 | `KapitelShelf__Database__Password` | `kapitelshelf`               | `KapitelShelf.Database.Password` |
+| `KapitelShelf__Domain`             | `https://localhost:5261`     | `KapitelShelf.Domain`            |

--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       KapitelShelf__Database__Host: host.docker.internal:5432
       KapitelShelf__Database__Username: kapitelshelf
       KapitelShelf__Database__Password: kapitelshelf
+      KapitelShelf__Domain: http://localhost:5261
     ports:
       - "5261:5261"
     volumes:

--- a/helm/kapitelshelf/templates/api.yaml
+++ b/helm/kapitelshelf/templates/api.yaml
@@ -26,11 +26,13 @@ spec:
               containerPort: {{ .Values.api.service.port }}
           env:
             - name: KapitelShelf__Database__Host
-              value: {{ include "postgresql.host" . }}
+              value: {{ include "postgresql.host" . | quote }}
             - name: KapitelShelf__Database__Username
-              value: {{ .Values.postgresql.auth.username }}
+              value: {{ .Values.postgresql.auth.username | quote }}
             - name: KapitelShelf__Database__Password
-              value: {{ .Values.postgresql.auth.password }}
+              value: {{ .Values.postgresql.auth.password | quote }}
+            - name: KapitelShelf__Domain
+              value: {{ include "kapitelshelf.api.host" . | quote }}
           volumeMounts:
             - mountPath: /var/lib/kapitelshelf/data
               name: data

--- a/helm/kapitelshelf/templates/frontend.yaml
+++ b/helm/kapitelshelf/templates/frontend.yaml
@@ -26,7 +26,7 @@ spec:
               containerPort: {{ .Values.frontend.service.port }}
           env:
             - name: VITE_KAPITELSHELF_API
-              value: {{ include "kapitelshelf.api.host" . }}
+              value: {{ include "kapitelshelf.api.host" . | quote }}
           resources: {{ toYaml .Values.frontend.resources | nindent 12 }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description

Fixes the configuration of the cloudstorages by setting the domain for helm charts automatically based on values.yaml.

## Motivation and Context

Cloudstorages are broken with the helm deployment.

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] Tests added/updated
- [x] Docs updated (if needed)

## Related Issue(s)

## Additional Notes
