### PR TITLE
fix: Redirect after adding a new CloudStorage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,6 @@
         }
       ]
     }
-  ]
+  ],
+  "java.configuration.updateBuildConfiguration": "disabled"
 }

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.kapitelshelf.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 301
-        versionName "0.3.1"
+        versionCode 300
+        versionName "0.3.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,14 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- CloudStorage OAuth RedirectUrl -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="kapitelshelf" android:host="auth" android:path="/callback" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/frontend/src/features/cloudstorage/OneDriveSettings.tsx
+++ b/frontend/src/features/cloudstorage/OneDriveSettings.tsx
@@ -13,6 +13,7 @@ import { ConfigureCloudConfigurationDialog } from "../../components/cloudstorage
 import { useApi } from "../../contexts/ApiProvider";
 import type { ConfigureCloudDTO } from "../../lib/api/KapitelShelf.Api/api";
 import { CloudTypeDTO } from "../../lib/api/KapitelShelf.Api/api";
+import { IsMobileApp } from "../../utils/MobileUtils";
 
 export const OneDriveSettings = (): ReactElement => {
   const { clients } = useApi();
@@ -46,8 +47,11 @@ export const OneDriveSettings = (): ReactElement => {
   const { mutate: startOAuthFlow } = useMutation({
     mutationKey: ["cloudstorage-onedrive-oauth-flow"],
     mutationFn: async () => {
+      const redirectUrl = IsMobileApp()
+        ? "kapitelshelf://auth/callback"
+        : window.location.href;
       const { data } = await clients.onedrive.cloudstorageOnedriveOauthGet(
-        window.location.href
+        redirectUrl
       );
       window.location.href = data;
     },


### PR DESCRIPTION
## Description

Currently, when adding a cloudstorage, at the end, you get redirected to a url and not to the KapitelShelf mobile app.

## Motivation and Context

BugFix

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] Tests added/updated
- [x] Docs updated (if needed)

## Related Issue(s)

## Additional Notes
