### PR TITLE
fix: close "add book" menu after clicking on one of the options

### DIFF
--- a/frontend/src/components/AppBar.tsx
+++ b/frontend/src/components/AppBar.tsx
@@ -2,7 +2,7 @@ import AddBoxIcon from "@mui/icons-material/AddBox";
 import FileUploadIcon from "@mui/icons-material/FileUpload";
 import NoteAddIcon from "@mui/icons-material/NoteAdd";
 import { Box, SpeedDial, SpeedDialAction, Stack } from "@mui/material";
-import type { ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ProfileMenu } from "../features/user/ProfileMenu";
@@ -48,12 +48,16 @@ export const AppBar = ({ open, toggle }: TopAppBarProps): ReactElement => {
 
 const AddBookActions = (): ReactElement => {
   const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
 
   return (
     <SpeedDial
       ariaLabel="Add Book"
       direction="down"
       icon={<AddBoxIcon />}
+      open={open}
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
       sx={{
         height: "36px",
         ">.MuiButtonBase-root": {
@@ -77,12 +81,18 @@ const AddBookActions = (): ReactElement => {
       <SpeedDialAction
         icon={<NoteAddIcon />}
         slotProps={{ tooltip: { title: "Create Book" } }}
-        onClick={() => navigate("/library/books/create")}
+        onClick={() => {
+          setOpen(false);
+          navigate("/library/books/create");
+        }}
       />
       <SpeedDialAction
         icon={<FileUploadIcon />}
         slotProps={{ tooltip: { title: "Import Book" } }}
-        onClick={() => navigate("/library/books/import")}
+        onClick={() => {
+          setOpen(false);
+          navigate("/library/books/import");
+        }}
       />
     </SpeedDial>
   );


### PR DESCRIPTION
## Description

Close the "add book" menu after clicking on one of the options.

## Motivation and Context

On android the "add book" speed dial doesnt closes after a click, while it should

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] Tests added/updated
- [x] Docs updated (if needed)

## Related Issue(s)

## Additional Notes
