### PR TITLE
feat: add frontend, api and helm version to readme

### DIFF
--- a/.versionrc.cjs
+++ b/.versionrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  header: "# Changelog\n",
-};

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 KapitelShelf is a modern web app for managing and reading your personal book library.  
 It supports both digital books (EPUB, PDF, etc.) and physical collections, with a clean interface for browsing and managing your library.
 
-[![License](https://img.shields.io/github/license/thomasmiller01/kapitelshelf?style=flat-square)](./LICENSE)
+[![Frontend Version](https://img.shields.io/badge/frontend-v0.3.1-0078D7)](./frontend/CHANGELOG.md)
+[![API Version](https://img.shields.io/badge/api-v0.3.1-28A745)](./backend/src/KapitelShelf.Api/CHANGELOG.md)
+[![Helm Chart](https://img.shields.io/badge/helm-v0.3.1-F97316)](./helm/kapitelshelf/README.md)
+[![License](https://img.shields.io/github/license/thomasmiller01/kapitelshelf)](./LICENSE)
 
 ![Home Page](./docs/.attachments/home_page.png)
 

--- a/backend/src/KapitelShelf.Api/.versionrc.cjs
+++ b/backend/src/KapitelShelf.Api/.versionrc.cjs
@@ -1,7 +1,19 @@
 module.exports = {
   header: "# Changelog\n",
   tagPrefix: "api@",
+  releaseCommitMessageFormat: "chore(release-api): v{{currentTag}}",
   path: ".",
   packageFiles: "KapitelShelf.Api.csproj",
-  bumpFiles: "KapitelShelf.Api.csproj",
+  bumpFiles: [
+    { filename: "./KapitelShelf.Api.csproj", type: "csproj" },
+    {
+      filename: "../../../README.md",
+      updater: {
+        readVersion: (contents) =>
+          contents.match(/api-v(\d+\.\d+\.\d+)/)?.[1] ?? "0.0.0",
+        writeVersion: (contents, version) =>
+          contents.replace(/api-v\d+\.\d+\.\d+/g, `api-v${version}`),
+      },
+    },
+  ],
 };

--- a/frontend/.versionrc.cjs
+++ b/frontend/.versionrc.cjs
@@ -1,8 +1,11 @@
 module.exports = {
   header: "# Changelog\n",
   tagPrefix: "frontend@",
+  releaseCommitMessageFormat: "chore(release-frontend): v{{currentTag}}",
   path: ".",
   bumpFiles: [
+    { filename: "./package.json", type: "json" },
+    { filename: "./package-lock.json", type: "json" },
     {
       filename: "../README.md",
       updater: {

--- a/frontend/.versionrc.cjs
+++ b/frontend/.versionrc.cjs
@@ -2,4 +2,15 @@ module.exports = {
   header: "# Changelog\n",
   tagPrefix: "frontend@",
   path: ".",
+  bumpFiles: [
+    {
+      filename: "../README.md",
+      updater: {
+        readVersion: (contents) =>
+          contents.match(/frontend-v(\d+\.\d+\.\d+)/)?.[1] ?? "0.0.0",
+        writeVersion: (contents, version) =>
+          contents.replace(/frontend-v\d+\.\d+\.\d+/g, `frontend-v${version}`),
+      },
+    },
+  ],
 };

--- a/helm/kapitelshelf/.versionrc.cjs
+++ b/helm/kapitelshelf/.versionrc.cjs
@@ -1,9 +1,21 @@
 module.exports = {
   header: "# Changelog\n",
   tagPrefix: "helm@",
+  releaseCommitMessageFormat: "chore(release-helm): v{{currentTag}}",
   path: ".",
   packageFiles: "Chart.yaml",
-  bumpFiles: "Chart.yaml",
+  bumpFiles: [
+    { filename: "./Chart.yaml", type: "yaml" },
+    {
+      filename: "../../README.md",
+      updater: {
+        readVersion: (contents) =>
+          contents.match(/helm-v(\d+\.\d+\.\d+)/)?.[1] ?? "0.0.0",
+        writeVersion: (contents, version) =>
+          contents.replace(/helm-v\d+\.\d+\.\d+/g, `helm-v${version}`),
+      },
+    },
+  ],
   scripts: {
     postchangelog: "cd ../../ && npm run gen:helm:docs",
     precommit: "git add README.md",


### PR DESCRIPTION
## Description

Add shields.io badges for the frontend, api and helm version to the root readme.

## Motivation and Context

Easier see the latest frontend, api and helm version.

## Type of Change

- [ ] Bugfix
- [ ] Feature / Enhancement
- [x] Maintenance

## Checklist

- [x] ~~Tests added/updated~~
- [x] ~~Docs updated (if needed)~~

## Related Issue(s)

## Additional Notes
