### PR TITLE
fix: fixed adding book from watchlist to library

### DIFF
--- a/backend/src/KapitelShelf.Api.Tests/Mappings/MapperWatchlistsTests.cs
+++ b/backend/src/KapitelShelf.Api.Tests/Mappings/MapperWatchlistsTests.cs
@@ -39,6 +39,7 @@ public class MapperWatchlistsTests
         // setup
         var model = new WatchlistResultModel
         {
+            Id = Guid.NewGuid(),
             Title = "Book Title",
             Description = "Desc",
             ReleaseDate = "2024-06-01",
@@ -59,6 +60,7 @@ public class MapperWatchlistsTests
         Assert.That(dto, Is.Not.Null);
         Assert.Multiple(() =>
         {
+            Assert.That(dto.Id, Is.EqualTo(model.Id));
             Assert.That(dto.Title, Is.EqualTo(model.Title));
             Assert.That(dto.Description, Is.EqualTo(model.Description));
             Assert.That(dto.ReleaseDate?.Date, Is.EqualTo(DateTime.Parse("2024-06-01", CultureInfo.InvariantCulture).ToUniversalTime().Date));

--- a/backend/src/KapitelShelf.Api/Controllers/WatchlistController.cs
+++ b/backend/src/KapitelShelf.Api/Controllers/WatchlistController.cs
@@ -129,7 +129,7 @@ public class WatchlistController(ILogger<WatchlistController> logger, IWatchlist
     /// <param name="resultId">The result id.</param>
     /// <returns>A <see cref="Task{IActionResult}"/> representing the result of the asynchronous operation.</returns>
     [HttpPut("result/{resultId}/library")]
-    public async Task<ActionResult<BookDTO>> AddSeriesToWatchlist(Guid resultId)
+    public async Task<ActionResult<BookDTO>> AddWatchlistResultToLibrary(Guid resultId)
     {
         try
         {

--- a/backend/src/KapitelShelf.Api/Mappings/Mapper.Watchlists.cs
+++ b/backend/src/KapitelShelf.Api/Mappings/Mapper.Watchlists.cs
@@ -31,6 +31,7 @@ public sealed partial class Mapper
 
         var dto = new BookDTO
         {
+            Id = model.Id,
             Title = model.Title,
             Description = model.Description ?? string.Empty,
             ReleaseDate = ParseDate(model.ReleaseDate),


### PR DESCRIPTION
## Description

When i try to add a release book from the watchlist to the library, the following error is shown: Adding book to library failed: Request failed with status code 404

## Motivation and Context

BugFix

## Type of Change

- [x] Bugfix
- [ ] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] Tests added/updated
- [x] Docs updated (if needed)

## Related Issue(s)

## Additional Notes
