### PR TITLE
Show next watchlist releases on home page

### DIFF
--- a/frontend/src/features/book/LastVisitedBooksList.tsx
+++ b/frontend/src/features/book/LastVisitedBooksList.tsx
@@ -39,15 +39,18 @@ const LastVisitedBooksList = (): ReactElement => {
     return <RequestErrorCard itemName="Last Visited Books" onRetry={refetch} />;
   }
 
-  if (data?.totalCount === 0) {
-    return <NoItemsFoundCard itemName="Last Visited Books" small />;
-  }
-
   return (
-    <ScrollableList title="Last Visited Books" itemWidth={150} itemGap={16}>
+    <ScrollableList
+      title="Last Visited Books"
+      itemWidth={data?.totalCount == 0 ? 450 : 150}
+      itemGap={16}
+    >
       {data?.items?.map((x) => (
         <BookCard key={x.id} book={x} small />
       ))}
+      {data?.totalCount === 0 && (
+        <NoItemsFoundCard itemName="Last Visited Books" extraSmall />
+      )}
     </ScrollableList>
   );
 };

--- a/frontend/src/features/watchlist/NextWatchlistReleases.tsx
+++ b/frontend/src/features/watchlist/NextWatchlistReleases.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+
+import LoadingCard from "../../components/base/feedback/LoadingCard";
+import { NoItemsFoundCard } from "../../components/base/feedback/NoItemsFoundCard";
+import { RequestErrorCard } from "../../components/base/feedback/RequestErrorCard";
+import { ScrollableList } from "../../components/ScrollableList";
+import { ResultCard } from "../../components/watchlist/ResultCard";
+import { useApi } from "../../contexts/ApiProvider";
+import { useUserProfile } from "../../hooks/useUserProfile";
+import { SplitByReleaseWindow } from "../../utils/WatchlistUtils";
+
+const NextWatchlistReleasesList = (): ReactElement => {
+  const { clients } = useApi();
+  const { profile } = useUserProfile();
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["watchlist", profile?.id],
+    queryFn: async () => {
+      if (profile?.id === undefined) {
+        return null;
+      }
+
+      const { data } = await clients.watchlist.watchlistGet(profile?.id);
+      return data;
+    },
+  });
+
+  if (isLoading) {
+    return <LoadingCard delayed itemName="Next Releases" small />;
+  }
+
+  if (isError) {
+    return <RequestErrorCard itemName="Next Releases" onRetry={refetch} />;
+  }
+
+  if (data === undefined || data === null || data.length === 0) {
+    return <NoItemsFoundCard itemName="Next Releases" small />;
+  }
+
+  const { arrivingSoon } = SplitByReleaseWindow(data);
+  const flattened = arrivingSoon.flatMap((x) => x.items ?? []);
+
+  return (
+    <ScrollableList
+      title="Next Releases"
+      itemWidth={flattened.length === 0 ? 415 : 150}
+      itemGap={16}
+    >
+      {flattened?.map((x) => (
+        <ResultCard key={x.id} book={x} />
+      ))}
+      {flattened.length == 0 && (
+        <NoItemsFoundCard itemName="Next Releases" extraSmall />
+      )}
+    </ScrollableList>
+  );
+};
+
+export default NextWatchlistReleasesList;

--- a/frontend/src/features/watchlist/Watchlist.tsx
+++ b/frontend/src/features/watchlist/Watchlist.tsx
@@ -8,7 +8,8 @@ import { WatchlistDetails } from "../../components/watchlist/WatchlistDetails";
 import { useApi } from "../../contexts/ApiProvider";
 import { useMobile } from "../../hooks/useMobile";
 import { useUserProfile } from "../../hooks/useUserProfile";
-import type { BookDTO, WatchlistDTO } from "../../lib/api/KapitelShelf.Api";
+import type { WatchlistDTO } from "../../lib/api/KapitelShelf.Api";
+import { SplitByReleaseWindow } from "../../utils/WatchlistUtils";
 
 const Watchlist: React.FC = () => {
   const { profile } = useUserProfile();
@@ -38,36 +39,7 @@ const Watchlist: React.FC = () => {
     return <NoItemsFoundCard itemName="Series on your Watchlist" extraSmall />;
   }
 
-  // get release date from the first item
-  const getFirstReleaseDate = (watchlist: WatchlistDTO): Date | null => {
-    const first: BookDTO | undefined = watchlist.items?.[0];
-    if (!first?.releaseDate) {
-      return null;
-    }
-    const date = new Date(first.releaseDate);
-    return isNaN(date.getTime()) ? null : date;
-  };
-
-  const now = new Date();
-  const weekFromNow = new Date(now);
-  weekFromNow.setDate(now.getDate() + 7);
-  const monthFromNow = new Date(now);
-  monthFromNow.setDate(now.getDate() + 30);
-
-  const arrivingSoon = data.filter((w) => {
-    const date = getFirstReleaseDate(w);
-    return date && date <= weekFromNow;
-  });
-
-  const comingUp = data.filter((w) => {
-    const date = getFirstReleaseDate(w);
-    return date && date > weekFromNow && date <= monthFromNow;
-  });
-
-  const later = data.filter((w) => {
-    const date = getFirstReleaseDate(w);
-    return !date || date > monthFromNow;
-  });
+  const { arrivingSoon, comingUp, later } = SplitByReleaseWindow(data);
 
   return (
     <Box>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { Box } from "@mui/material";
 import type { ReactElement } from "react";
 
 import LastVisitedBooksList from "../features/book/LastVisitedBooksList";
+import NextWatchlistReleasesList from "../features/watchlist/NextWatchlistReleases";
 import WelcomeScreen from "../features/WelcomeScreen";
 import { useWelcomeScreen } from "../hooks/useWelcomeScreen";
 
@@ -23,6 +24,7 @@ const HomePage = (): ReactElement => {
 
   return (
     <Box sx={{ margin: "10px" }}>
+      <NextWatchlistReleasesList />
       <LastVisitedBooksList />
     </Box>
   );

--- a/frontend/src/utils/WatchlistUtils.tsx
+++ b/frontend/src/utils/WatchlistUtils.tsx
@@ -1,4 +1,8 @@
-import type { SeriesDTO } from "../lib/api/KapitelShelf.Api";
+import type {
+  BookDTO,
+  SeriesDTO,
+  WatchlistDTO,
+} from "../lib/api/KapitelShelf.Api";
 import { LocationTypeDTO } from "../lib/api/KapitelShelf.Api";
 
 const LocationsSupportSeriesWatchlist: number[] = [LocationTypeDTO.NUMBER_2];
@@ -13,4 +17,48 @@ export const SeriesSupportsWatchlist = (
   return LocationsSupportSeriesWatchlist.includes(
     series.lastVolume.location.type
   );
+};
+
+// get release date from the first item
+export const GetFirstReleaseDate = (watchlist: WatchlistDTO): Date | null => {
+  const first: BookDTO | undefined = watchlist.items?.[0];
+  if (!first?.releaseDate) {
+    return null;
+  }
+
+  const date = new Date(first.releaseDate);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const SplitByReleaseWindow = (
+  data: WatchlistDTO[]
+): {
+  arrivingSoon: WatchlistDTO[];
+  comingUp: WatchlistDTO[];
+  later: WatchlistDTO[];
+} => {
+  const now = new Date();
+
+  const weekFromNow = new Date(now);
+  weekFromNow.setDate(now.getDate() + 7);
+
+  const monthFromNow = new Date(now);
+  monthFromNow.setDate(now.getDate() + 30);
+
+  return {
+    arrivingSoon: data.filter((w) => {
+      const date = GetFirstReleaseDate(w);
+      return !!date && date <= weekFromNow;
+    }),
+
+    comingUp: data.filter((w) => {
+      const date = GetFirstReleaseDate(w);
+      return !!date && date > weekFromNow && date <= monthFromNow;
+    }),
+
+    later: data.filter((w) => {
+      const date = GetFirstReleaseDate(w);
+      return !date || date > monthFromNow;
+    }),
+  };
 };


### PR DESCRIPTION
## Description

Show what books will be released next on the home page

## Motivation and Context

I want to quickly see which books are released next from my watchlist.

## Type of Change

- [ ] Bugfix
- [x] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] ~~Tests added/updated~~
- [x] ~~Docs updated (if needed)~~

## Related Issue(s)

## Additional Notes
