### PR TITLE
refactor: return 5 instead of 10 items for book autocomplete

### DIFF
--- a/backend/src/KapitelShelf.Api.Tests/Logic/BooksLogicTests.cs
+++ b/backend/src/KapitelShelf.Api.Tests/Logic/BooksLogicTests.cs
@@ -1716,7 +1716,7 @@ public class BooksLogicTests
 
         // assert
         Assert.That(result, Is.Not.Null);
-        Assert.That(result, Has.Count.LessThanOrEqualTo(10));
+        Assert.That(result, Has.Count.EqualTo(5));
         Assert.That(result.All(x => x.Contains(prefix, StringComparison.OrdinalIgnoreCase)), Is.True);
     }
 
@@ -1806,7 +1806,7 @@ public class BooksLogicTests
 
         // assert
         Assert.That(result, Is.Not.Null);
-        Assert.That(result, Has.Count.LessThanOrEqualTo(10));
+        Assert.That(result, Has.Count.EqualTo(5));
         Assert.Multiple(() =>
         {
             Assert.That(result.All(x => x.Contains(token, StringComparison.OrdinalIgnoreCase)), Is.True);
@@ -1899,7 +1899,7 @@ public class BooksLogicTests
 
         // assert
         Assert.That(result, Is.Not.Null);
-        Assert.That(result, Has.Count.LessThanOrEqualTo(10));
+        Assert.That(result, Has.Count.EqualTo(5));
         Assert.That(result.All(x => x.Contains(prefix, StringComparison.OrdinalIgnoreCase)), Is.True);
     }
 
@@ -1987,7 +1987,7 @@ public class BooksLogicTests
 
         // assert
         Assert.That(result, Is.Not.Null);
-        Assert.That(result, Has.Count.LessThanOrEqualTo(10));
+        Assert.That(result, Has.Count.EqualTo(5));
         Assert.That(result.All(x => x.Contains(prefix, StringComparison.OrdinalIgnoreCase)), Is.True);
     }
 

--- a/backend/src/KapitelShelf.Api/Logic/BooksLogic.cs
+++ b/backend/src/KapitelShelf.Api/Logic/BooksLogic.cs
@@ -543,7 +543,7 @@ public class BooksLogic(
             .AsNoTracking()
             .FilterBySeriesNameQuery(partialSeriesName)
             .SortBySeriesNameQuery(partialSeriesName)
-            .Take(10)
+            .Take(5)
             .Select(x => x.Name)
             .ToListAsync();
     }
@@ -562,7 +562,7 @@ public class BooksLogic(
             .AsNoTracking()
             .FilterByAuthorQuery(partialAuthor)
             .SortByAuthorQuery(partialAuthor)
-            .Take(10)
+            .Take(5)
             .Select(x => x.FirstName + " " + x.LastName)
             .ToListAsync();
     }
@@ -581,7 +581,7 @@ public class BooksLogic(
             .AsNoTracking()
             .FilterByCategoryQuery(partialCategoryName)
             .SortByCategoryQuery(partialCategoryName)
-            .Take(10)
+            .Take(5)
             .Select(x => x.Name)
             .ToListAsync();
     }
@@ -600,7 +600,7 @@ public class BooksLogic(
             .AsNoTracking()
             .FilterByTagQuery(partialTagName)
             .SortByTagQuery(partialTagName)
-            .Take(10)
+            .Take(5)
             .Select(x => x.Name)
             .ToListAsync();
     }


### PR DESCRIPTION
## Description

Change autocomplete to return 5 items instead of 10 for better readability on mobile.

## Motivation and Context

QoL

## Type of Change

- [ ] Bugfix
- [x] Feature / Enhancement
- [ ] Maintenance

## Checklist

- [x] ~~Tests added/updated~~
- [x] ~~Docs updated (if needed)~~

## Related Issue(s)

## Additional Notes
